### PR TITLE
configure Next.js to render Styled Components server-side (SSR)

### DIFF
--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,0 +1,39 @@
+import Document, { DocumentContext,  Head, Html, Main, NextScript } from 'next/document'
+import { ServerStyleSheet } from 'styled-components'
+
+export default class MyDocument extends Document {
+  static async getInitialProps(ctx: DocumentContext) {
+    const sheet = new ServerStyleSheet()
+    const originalRenderPage = ctx.renderPage
+
+    try {
+      ctx.renderPage = () =>
+        originalRenderPage({
+          enhanceApp: (App) => (props) =>
+            sheet.collectStyles(<App {...props} />),
+        })
+
+      const initialProps = await Document.getInitialProps(ctx)
+      return {
+        ...initialProps,
+        styles: [initialProps.styles, sheet.getStyleElement()],
+      }
+    } finally {
+      sheet.seal()
+    }
+  }
+
+  render () {
+    return (
+        <Html>
+            <Head>
+                
+            </Head>
+            <body>
+                <Main />
+                <NextScript />
+            </body>
+        </Html>
+    )
+  }
+}


### PR DESCRIPTION
This PR adds the necessary configuration to render server-side Styled Components (SSR) in the Next.js project. To do this, I created the _document.tsx file in the pages folder with the necessary code to collect the component styles and render them on the server.

With these changes, Styled Components will now be rendered on the server side, improving application performance and fixing some visual bugs.