### PR TITLE
Implement card with roulette info

### DIFF
--- a/src/components/LuckyWheelWithButtonAndPanel/index.tsx
+++ b/src/components/LuckyWheelWithButtonAndPanel/index.tsx
@@ -3,13 +3,14 @@ import React, { useEffect, useState } from 'react';
 import {LuckWheelPrize, LuckyWheel} from '@lucky-canvas/react'
 import { useReward } from 'react-rewards';
 import Div from './style'
-import { Web3Button, useAddress } from '@thirdweb-dev/react';
+import { Web3Button, useAddress, useContract } from '@thirdweb-dev/react';
 import style from "./style.module.css"
 import Image from "next/image"
 import styled from "styled-components"
 import { SmartContract } from '@thirdweb-dev/sdk';
 import RouletteWinners from '../RouletteWinners';
 import { Button } from '@chakra-ui/react';
+import RouletteInfoCard from '../RouletteInfoCard';
 
   const LogoContainer = styled.div`
     z-index: 999;
@@ -147,5 +148,6 @@ import { Button } from '@chakra-ui/react';
         <Button isDisabled={isSpinning || (amountOfSpin === 30)} marginTop={2} width={3} height={'34px'} onClick={handleIncrement}>+</Button>
         </div>
         </Div>
+        <RouletteInfoCard rouletteWinner={rouletteWinner} drawResult={drawResult} amountOfSpin={amountOfSpin} contract={props.contract.address}/>
   </>
   }

--- a/src/components/RouletteInfoCard/index.tsx
+++ b/src/components/RouletteInfoCard/index.tsx
@@ -1,0 +1,71 @@
+import {useEffect, useState} from 'react'
+import { Card, CardBody, CardHeader, Center, Divider, Grid, GridItem } from "@chakra-ui/react";
+import { useAddress, useContract } from "@thirdweb-dev/react";
+
+export default function RouletteInfoCard(props: RouletteInfoCardProps){
+    const [playerInfo, setPlayerInfo] = useState<RoulettePlayerInfo>({spins: 0})
+    const [bonusSpin, setBonusSpin] = useState(0)
+    const [bonusSpinUsed, setBonusSpinUsed] = useState(0)
+    const { contract } = useContract(props.contract)
+    const address = useAddress()
+    const spinCost = bonusSpinUsed - bonusSpin
+    
+    useEffect(()=> {
+        address && contract?.call('playerInfo', address).then(data => {
+            setPlayerInfo(data)
+            setBonusSpin(Number(data.spins))
+      })
+    },[address])
+    
+    useEffect(()=> {
+        if((bonusSpin >= bonusSpinUsed)){
+            setBonusSpin(bonusSpin - bonusSpinUsed)
+        }else{
+            setBonusSpin(0)
+        }
+    },[props.drawResult])
+
+    useEffect(()=> {
+        console.log(props.rouletteWinner);
+        if(props.rouletteWinner?.name === '1 Spin')
+        setBonusSpin(bonusSpin + 1)
+    }, [props.rouletteWinner])
+
+    useEffect(()=> {
+        setBonusSpinUsed(bonusSpin - (bonusSpin - props.amountOfSpin))
+    }, [bonusSpin, props.amountOfSpin])
+    return <Card
+        marginTop={5}
+        backgroundColor="#1A202C"
+        borderColor='white'
+        borderWidth={1}
+        width={350}
+        height={450}
+    >
+        <Center>
+            <CardHeader fontSize={20}>My Spin Info</CardHeader>
+        </Center>
+        <Center>
+        <Divider width={'90%'}></Divider>
+        </Center>
+        <CardBody>
+            <Grid templateColumns='repeat(4, 1fr)'  rowGap={2}>
+                <GridItem colSpan={3}>Bonus spin available:</GridItem><GridItem colSpan={1}>{bonusSpin}</GridItem>
+            </Grid>
+        </CardBody>
+        <Divider></Divider>
+        <Center>
+            <CardHeader fontSize={20}>Next Spin Info</CardHeader>
+        </Center>
+        <Center>
+        <Divider width={'90%'}></Divider>
+        </Center>
+        <CardBody>
+            <Grid templateColumns='repeat(4, 1fr)'  rowGap={1}>
+                <GridItem colSpan={3}>Number of spin:</GridItem><GridItem colSpan={1}>{props.amountOfSpin}</GridItem>
+                <GridItem colSpan={3}>Bonus Spins in use:</GridItem><GridItem colSpan={1}>{(bonusSpin > props.amountOfSpin)? bonusSpinUsed : bonusSpin}</GridItem>
+                <GridItem colSpan={3}>Total cost of spin:</GridItem><GridItem colSpan={1}>{spinCost > 0 ? spinCost : 0} POSI</GridItem>
+            </Grid>
+        </CardBody>
+    </Card>
+}

--- a/src/components/RouletteInfoCard/types.d.ts
+++ b/src/components/RouletteInfoCard/types.d.ts
@@ -1,0 +1,10 @@
+interface RoulettePlayerInfo {
+    spins: number
+}
+
+interface RouletteInfoCardProps {
+    amountOfSpin: number
+    contract: string
+    drawResult: any
+    rouletteWinner: {id: number, name: string} | null
+}


### PR DESCRIPTION
Implements a new card that displays player (user) information and next spin information.
The part with player information shows the amount of spins the user has available
on roulette.
The part that shows the information of the next spin displays the amount of spins that will be played, the amount of spin that will be used from the available bonus and the total cost of the spins.

![image](https://user-images.githubusercontent.com/81600458/227195447-01c772db-3965-4157-ba58-e3033d815563.png)
