### PR TITLE
fix: Error: Node.js version 16.x has reached End-of-Life

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,5 +43,8 @@
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-prettier": "^4.2.1",
     "prettier": "^2.7.1"
+  },
+  "engines": {
+    "node": ">=18.0.0"
   }
 }


### PR DESCRIPTION
Fix this error displayed in the vercel deploy:

> Error: Node.js version 16.x has reached End-of-Life. Deployments created on or after 2024-02-06 will fail to build. Please set Node.js Version to 18.x in your Project Settings to use Node.js 18.
